### PR TITLE
Include other modules.

### DIFF
--- a/Hagl.cabal
+++ b/Hagl.cabal
@@ -38,5 +38,5 @@ source-repository head
 
 library
   exposed-modules:     Hagl, Hagl.Examples, Hagl.Exec, Hagl.Extensive, Hagl.Game, Hagl.Lists, Hagl.Normal, Hagl.Payoff, Hagl.Print, Hagl.StateGames, Hagl.Strategy, Hagl.Tournament, Hagl.Examples.Auction, Hagl.Examples.Chance, Hagl.Examples.Crisis, Hagl.Examples.Matrix, Hagl.Examples.Prisoner, Hagl.Examples.RPS, Hagl.Examples.TicTacToe
-  -- other-modules:       
+  other-modules:       Hagl.History, Hagl.Simultaneous
   build-depends:       base ==4.5.*, mtl ==2.1.*, containers ==0.4.*, transformers ==0.3.*, random ==1.0.*


### PR DESCRIPTION
Fix issue #1 by including modules missing from cabal package.
