### PR TITLE
Add chance node to nuclear war.

### DIFF
--- a/Hagl/Examples/Crisis.hs
+++ b/Hagl/Examples/Crisis.hs
@@ -31,7 +31,7 @@ crisis = start
         usa  = player 2
         nukesInTurkey = pays [  -2,   1]
         nukesInCuba   = pays [   1,  -2]
-        nuclearWar    = pays [-100,-100]
+        nuclearWar    = chance [(1, "Truly devastating war"), (4, "Devastating war")] [("Truly devastating war", pays [-100,-100]), ("Devastating war", pays [-20, -20])]
         noNukes       = pays [   0,   0]
         start = ussr ("Send Missiles to Cuba", usaResponse) 
                  <|> ("Do Nothing", nukesInTurkey)


### PR DESCRIPTION
Changed the missile crisis example to include the chance node from the JFP09 article. The example looks a little different in the current code base, and especially the chance node took a little time to figure out for me, so I thought it might help others who are trying to translate between the article and the current API.
