### PR TITLE
Small cabal package and GHC version updates

### DIFF
--- a/Hagl.cabal
+++ b/Hagl.cabal
@@ -10,7 +10,7 @@ maintainer:          eric@walkingshaw.net
 category:            Game Theory
 build-type:          Simple
 cabal-version:       >=1.8
-description:         
+description:
   A DSEL for experimental game theory (also called evolutionary game theory and
   behavioral economics).  Supports defining games and strategies, then executing
   them repeatedly in order to collect and observe the results.
@@ -38,5 +38,12 @@ source-repository head
 
 library
   exposed-modules:     Hagl, Hagl.Examples, Hagl.Exec, Hagl.Extensive, Hagl.Game, Hagl.Lists, Hagl.Normal, Hagl.Payoff, Hagl.Print, Hagl.StateGames, Hagl.Strategy, Hagl.Tournament, Hagl.Examples.Auction, Hagl.Examples.Chance, Hagl.Examples.Crisis, Hagl.Examples.Matrix, Hagl.Examples.Prisoner, Hagl.Examples.RPS, Hagl.Examples.TicTacToe
-  -- other-modules:       
-  build-depends:       base ==4.5.*, mtl ==2.1.*, containers ==0.4.*, transformers ==0.3.*, random ==1.0.*
+
+  -- other-modules:
+  build-depends:
+                base >=4.5,
+                mtl >=2.1,
+                containers >=0.4,
+                transformers >=0.3,
+                random >=1.0
+

--- a/Hagl/Examples/Prisoner.hs
+++ b/Hagl/Examples/Prisoner.hs
@@ -54,11 +54,11 @@ stag = symmetric [C,D] [3,0,2,1]
 
 -- | Always defects.
 fink :: Player Dilemma
-fink = "Fink" ::: pure D
+fink = "Fink" ::: pureStrat D
 
 -- | Always cooperates.
 mum :: Player Dilemma
-mum = "Mum" ::: pure C
+mum = "Mum" ::: pureStrat C
 
 -- | Alternates between cooperation and defection.
 alt :: Player Dilemma
@@ -102,7 +102,7 @@ mod3 = Player "Mod3 Cooperator" 0 $
   do i <- get
      put (i+1)
      return $ if i `mod` 3 == 0 then C else D
-     
+
 -- | Suspicious Tit-for-Tat.  Like Tit-for-Tat but defect on first move.
 suspicious :: Player Dilemma
 suspicious = "Suspicious Tit-for-Tat" ::: play D `atFirstThen` his (lastGame's onlyMove)
@@ -123,7 +123,7 @@ grim = "Grim Trigger" :::
 -- | The Grim Trigger, implemented using state.  Much faster than 'grim', since
 --   it doesn't examine every previous game iteration.
 grim' :: Player Dilemma
-grim' = Player "Stately Grim" False $ 
+grim' = Player "Stately Grim" False $
   play C `atFirstThen`
   do m <- her (lastGame's onlyMove)
      triggered <- update (|| m == D)

--- a/Hagl/Examples/RPS.hs
+++ b/Hagl/Examples/RPS.hs
@@ -36,7 +36,7 @@ rps = square [Rock .. Scissors] [0,-1, 1,
 --
 
 -- | Good ol' rock, nothing beats that.
-rocky  = "Stalone" ::: pure Rock
+rocky  = "Stalone" ::: pureStrat Rock
 
 -- | Rotates through all three options in a cycle.
 rotate = "RPS" ::: periodic [Rock, Paper, Scissors]
@@ -62,6 +62,6 @@ frequency = "Huckleberry" :::
            p = length $ filter (Paper ==) ms
            s = length $ filter (Scissors ==) ms
            x = maximum [r,p,s]
-        in return $ if x == r then Paper else 
+        in return $ if x == r then Paper else
                     if x == p then Scissors
                               else Rock

--- a/Hagl/Exec.hs
+++ b/Hagl/Exec.hs
@@ -315,9 +315,6 @@ times n = numPlaying >>= go n . tie
 --
 -- Instances
 --
--- data ExecM g a = ExecM { unE :: StateT (Exec g) IO a }
--- instance Functor (ExecM g)  where
---   fmap f (ExecM g) = ExecM $ (fmap . fmap) ExecM g
 
 instance Functor (ExecM g) where
   fmap = liftM

--- a/Hagl/Normal.hs
+++ b/Hagl/Normal.hs
@@ -1,7 +1,6 @@
-{-# LANGUAGE FlexibleInstances,
-             FunctionalDependencies,
-             MultiParamTypeClasses,
-             TypeFamilies #-}
+
+{-# LANGUAGE FlexibleInstances, FunctionalDependencies, MultiParamTypeClasses, TypeFamilies #-}
+{-# LANGUAGE PatternGuards #-}
 
 -- | This module provides different representations of normal form games, smart
 --   constructors for creating them, and functions for analyzing them.
@@ -28,7 +27,7 @@ import Hagl.Simultaneous
 --   interface for grid-structured games.
 class IsNormal g mv | g -> mv where
   toNormal :: g -> Normal mv
-  
+
 -- | A general normal form game.  Arguments are the number of players,
 --   a list of moves available to each player, and the payoff corresponding
 --   to each potential combination of moves.
@@ -175,11 +174,11 @@ instance Eq mv => IsSimultaneous (Matrix mv) mv where
   toSimultaneous = toSimultaneous . toNormal
 
 instance Eq mv => Game (Normal mv) where
-  
-  type TreeType (Normal mv) = Discrete 
+
+  type TreeType (Normal mv) = Discrete
   type State    (Normal mv) = ()
   type Move     (Normal mv) = mv
-  
+
   gameTree g = tree 1 []
     where
       tree p ms
@@ -187,7 +186,7 @@ instance Eq mv => Game (Normal mv) where
         | otherwise         = (payoff . getPayoff g . ByPlayer . reverse) ms
 
 instance Eq mv => Game (Matrix mv) where
-  type TreeType (Matrix mv) = Discrete 
+  type TreeType (Matrix mv) = Discrete
   type State    (Matrix mv) = ()
   type Move     (Matrix mv) = mv
   gameTree = gameTree . toNormal
@@ -217,7 +216,7 @@ showNormal g = show (gameTree g)
 --    are the same length...)
 showGrid :: Show mv => [mv] -> [mv] -> [Payoff] -> String
 showGrid rs cs vs = showRows (colHead : zipWith (:) rowHead grid)
-  where 
+  where
     rs' = map show rs
     cs' = map show cs
     vs' = chunk (length cs) (map showPayoff vs)
@@ -228,26 +227,26 @@ showGrid rs cs vs = showRows (colHead : zipWith (:) rowHead grid)
 
     padLeft :: Int -> String -> String
     padLeft n s = replicate (n - length s) ' ' ++ s
-    
+
     pad :: Int -> String -> String
     pad n s | length s <  n-1 = pad n (' ' : s ++ " ")
             | length s == n-1 = ' ' : s
             | otherwise       = s
-    
+
     maxLength :: [String] -> Int
     maxLength = maximum . map length
-    
+
     gridMax :: [[String]] -> Int
     gridMax = maximum . map maxLength
-    
+
     showRow :: [String] -> String
     showRow = intercalate " | "
-    
+
     showRows :: [[String]] -> String
     showRows = unlines . map showRow
-    
+
     toGrid :: [mv] -> [Payoff] -> [[Payoff]]
     toGrid = chunk . length
-    
+
     extractGrid :: Eq mv => ByPlayer [mv] -> [Payoff] -> [mv] -> [Payoff]
     extractGrid mss ps ms = [vs | (ByPlayer ms', vs) <- payoffMap mss ps, ms `isPrefixOf` ms']

--- a/Hagl/Normal.hs
+++ b/Hagl/Normal.hs
@@ -1,6 +1,8 @@
-
-{-# LANGUAGE FlexibleInstances, FunctionalDependencies, MultiParamTypeClasses, TypeFamilies #-}
-{-# LANGUAGE PatternGuards #-}
+{-# LANGUAGE FlexibleInstances,
+             FunctionalDependencies,
+             MultiParamTypeClasses,
+             PatternGuards,
+             TypeFamilies #-}
 
 -- | This module provides different representations of normal form games, smart
 --   constructors for creating them, and functions for analyzing them.

--- a/Hagl/Strategy.hs
+++ b/Hagl/Strategy.hs
@@ -25,8 +25,8 @@ import Hagl.Exec
 --
 
 -- | A pure strategy. Always plays the same move.
-pure :: Move g -> Strategy s g
-pure = return
+pureStrat :: Move g -> Strategy s g
+pureStrat = return
 
 -- | A mixed strategy. Plays moves based on a distribution.
 mixed :: Dist (Move g) -> Strategy s g
@@ -47,7 +47,7 @@ human = me >>= liftIO . getMove . name
         retry n e | isUserError e = putStrLn "Not a valid move... try again." >> getMove n
                   | otherwise     = ioError e
 
--- | Minimax strategy.  Computes the best move for the current player. 
+-- | Minimax strategy.  Computes the best move for the current player.
 --   Conceptually explores the entire game tree, but implements alpha-beta
 --   pruning for efficiency.  Assumes games without chance.
 minimax :: DiscreteGame g => Strategy s g
@@ -117,7 +117,7 @@ his :: GameM m g => m (ByPlayer a) -> m a
 his x = check >> liftM2 (forPlayer . nextPlayer 2) myPlayerID x
   where check = numPlaying >>= \np -> unless (np == 2) $
                 fail "his/her can only be used in two player games."
-                              
+
 -- | Selects the element corresponding to the other player in a two-player game.
 her :: GameM m g => m (ByPlayer a) -> m a
 her = his


### PR DESCRIPTION

I noticed that the cabal package version restrictions were a little outdated (after running cabal repl), so I've bumped it up a little.

I've also added functor/applicative instances for a few data types in `Exec.hs` in preparation for GHC 7.10's Functor-Applicative-Monad proposal.

